### PR TITLE
Fix gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .Ruserdata
 *.Rproj
 inst/doc
+tmp/*

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,4 +37,5 @@ Imports:
     tibble,
     tidyr,
     readr,
-    knitr
+    knitr,
+    gitignore

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ BugReports: https://github.com/RHReynolds/rprojecttemplate/issues
 biocViews: Software
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3
 Suggests: 
     BiocStyle,
     covr,
@@ -38,4 +38,5 @@ Imports:
     tidyr,
     readr,
     knitr,
-    gitignore
+    gitignore,
+    xfun

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ NEW FEATURES
 
 FIXES
 
+* [#0c8450e](https://github.com/RHReynolds/rprojecttemplate/commit/0c8450ed928ce5b17aac16aa07ab9ce0293c9d28): fixed error with `setup_project()` that prevented `.gitignore` being copied over when generating project
 * [#481ad7c](https://github.com/RHReynolds/rprojecttemplate/commit/481ad7c9829f6a06f9881ac26464ccdce5df25c0): fixed error with `update_index()` that occurred when `include_number = FALSE`
 
 # rprojecttemplate 0.99.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@ NEW FEATURES
 
 * Added a project template for GitLab, which can be accessed by using argument `type` in `setup_project()`.
 * `update_index()`: function that will generate an md-formatted table containing links to .htmls in a specified folder. This function can be used to generate the `index.html` page that will serve as the landing page for GitLab pages or GitHub pages. 
+* Added tests for `setup_project()`
 
 FIXES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,9 @@ NEW FEATURES
 
 FIXES
 
-* [#0c8450e](https://github.com/RHReynolds/rprojecttemplate/commit/0c8450ed928ce5b17aac16aa07ab9ce0293c9d28): fixed error with `setup_project()` that prevented `.gitignore` being copied over when generating project
+* [#0c8450e](https://github.com/RHReynolds/rprojecttemplate/commit/0c8450ed928ce5b17aac16aa07ab9ce0293c9d28): fixed error with `setup_project()` that prevented `.gitignore` being copied over when generating project. Resulted in addition of 2 new arguments:
+    * `add_gitignore` - default set to TRUE for backwards compatibility
+    * `gitignore_template` - default set to "r" for backwards compatibility
 * [#481ad7c](https://github.com/RHReynolds/rprojecttemplate/commit/481ad7c9829f6a06f9881ac26464ccdce5df25c0): fixed error with `update_index()` that occurred when `include_number = FALSE`
 
 # rprojecttemplate 0.99.0

--- a/R/setup_project.R
+++ b/R/setup_project.R
@@ -32,6 +32,8 @@
 #' @param path A path to a new directory.
 #' @param type chr. Vector specifying whether this project will be hosted on
 #'   github or gitlab. Default is github.
+#' @param gitignore_template chr. A character vector using values included in
+#'   \code{\link[gitignore:gi_available_templates.]{name}}. Default is "r".
 #'
 #' @return Project setup with folders and files necessary for a standard
 #'   research project.
@@ -46,7 +48,8 @@
 setup_project <-
     function(
       path,
-      type = c("github", "gitlab")
+      type = c("github", "gitlab"),
+      gitignore_template = "r"
       ) {
         stopifnot(is.character(path))
         proj_path <- fs::path_abs(path)
@@ -76,6 +79,12 @@ setup_project <-
                 )
             )
         }
+        
+        cli::cli_alert_info(
+          c(
+            "The {.val {proj_path}} folder is being created."
+          )
+        )
         
         if(type == "github"){
           
@@ -138,6 +147,12 @@ setup_project <-
           )
           
         }
+        
+        # create R-based gitignore file
+        gitignore::gi_write_gitignore(
+          gitignore::gi_fetch_templates(gitignore_template), 
+          gitignore_file = file.path(proj_path, ".gitignore")
+          )
         
     }
 

--- a/R/setup_project.R
+++ b/R/setup_project.R
@@ -32,8 +32,10 @@
 #' @param path A path to a new directory.
 #' @param type chr. Vector specifying whether this project will be hosted on
 #'   github or gitlab. Default is github.
+#' @param add_gitignore logical. Specify whether gitignore should be added.
+#'   Default is TRUE.
 #' @param gitignore_template chr. A character vector using values included in
-#'   \code{\link[gitignore:gi_available_templates.]{name}}. Default is "r".
+#'   \code{\link[gitignore]{gi_available_templates}}. Default is "r".
 #'
 #' @return Project setup with folders and files necessary for a standard
 #'   research project.
@@ -49,6 +51,7 @@ setup_project <-
     function(
       path,
       type = c("github", "gitlab"),
+      add_gitignore = TRUE,
       gitignore_template = "r"
       ) {
         stopifnot(is.character(path))
@@ -57,7 +60,11 @@ setup_project <-
         
         if(length(type) > 1){
           rlang::warn(
-            "More than one project type provided. User must choose between github/gitlab-friendly format. Will use github-friendly template."
+            c(
+              "More than one project type provided.", 
+              " User must choose between github/gitlab-friendly format.", 
+              " Default github-friendly template used." 
+            )
           )
           type <- "github"
           
@@ -79,12 +86,6 @@ setup_project <-
                 )
             )
         }
-        
-        cli::cli_alert_info(
-          c(
-            "The {.val {proj_path}} folder is being created."
-          )
-        )
         
         if(type == "github"){
           
@@ -148,11 +149,33 @@ setup_project <-
           
         }
         
-        # create R-based gitignore file
-        gitignore::gi_write_gitignore(
-          gitignore::gi_fetch_templates(gitignore_template), 
-          gitignore_file = file.path(proj_path, ".gitignore")
+        cli::cli_alert_success(
+          c(
+            "The {.val {proj_path}} folder has been created."
           )
+        )
+        
+        
+        if(add_gitignore == TRUE){
+          # fetch gitignore template
+          cli::cli_alert_info(
+            c(
+              "Fetching the specified gitignore template."
+            )
+          )
+          gi_template <- gitignore::gi_fetch_templates(gitignore_template, copy_to_clipboard = TRUE)
+          
+          # write gitignore
+          xfun::write_utf8(
+            gi_template, 
+            file.path(proj_path, ".gitignore")
+            )
+          cli::cli_alert_success(
+            c(
+              "The {.val {file.path(proj_path, '.gitignore')}} has been created."
+            )
+          )
+        }
         
     }
 

--- a/inst/templates/projects/basic-analysis-gitlab/.gitignore
+++ b/inst/templates/projects/basic-analysis-gitlab/.gitignore
@@ -1,6 +1,0 @@
-.Rproj.user
-.Rhistory
-.RData
-.Ruserdata
-.DS_Store
-tmp/*

--- a/man/setup_project.Rd
+++ b/man/setup_project.Rd
@@ -5,13 +5,24 @@
 \title{Setup a standardized folder and file structure for a research analysis
 project.}
 \usage{
-setup_project(path, type = c("github", "gitlab"))
+setup_project(
+  path,
+  type = c("github", "gitlab"),
+  add_gitignore = TRUE,
+  gitignore_template = "r"
+)
 }
 \arguments{
 \item{path}{A path to a new directory.}
 
 \item{type}{chr. Vector specifying whether this project will be hosted on
 github or gitlab. Default is github.}
+
+\item{add_gitignore}{logical. Specify whether gitignore should be added.
+Default is TRUE.}
+
+\item{gitignore_template}{chr. A character vector using values included in
+\code{\link[gitignore]{gi_available_templates}}. Default is "r".}
 }
 \value{
 Project setup with folders and files necessary for a standard

--- a/man/update_index.Rd
+++ b/man/update_index.Rd
@@ -25,11 +25,12 @@ will be ordered alphabetically. Default is TRUE.}
 \item{include_description}{boolean. Whether to include a description of the
 analysis, which will be taken straight from the \code{.rmd}. This function
 assumes that that this description is described in the section preceded by
-"> Aim:" and ended with "<br><br>", as in the example analysis templates
+"> Aim:" and ended with "\if{html}{\out{<br>}}\if{html}{\out{<br>}}", as in the example analysis templates
 available in both templates. Both of these templates were generated using:
 https://github.com/RHReynolds/rmdplate. Default is TRUE.}
 
-\item{md_formatting}{boolean. Whether \code{\link[tibble:tbl_df-class]{tibble}} should be returned with md formatting. Default is TRUE.}
+\item{md_formatting}{boolean. Whether \code{\link[tibble:tbl_df-class]{tibble}} should
+be returned with md formatting. Default is TRUE.}
 }
 \value{
 A \code{\link[tibble:tbl_df-class]{tibble}}, containing the title of each

--- a/tests/testthat/test-example_test.R
+++ b/tests/testthat/test-example_test.R
@@ -1,3 +1,0 @@
-test_that("multiplication works", {
-    expect_equal(2 * 2, 4)
-})

--- a/tests/testthat/test-projects.R
+++ b/tests/testthat/test-projects.R
@@ -1,0 +1,63 @@
+# project creation - github ----------------------------------------------------
+new_project <- fs::path_temp("testing")
+setup_project(new_project, type = "github", add_gitignore = TRUE)
+
+test_that("project is set up", {
+  expect_true(fs::dir_exists(new_project))
+  
+  files_created <- fs::dir_ls(new_project, recurse = TRUE, all = TRUE)
+  folders_created <- fs::dir_ls(new_project, type = "directory")
+  expect_equal(sort(basename(folders_created)),
+               sort(c("R", "docs", "logs", "raw_data", "results", "scripts")))
+  
+  expect_match(files_created, ".*DESCRIPTION$", all = FALSE)
+  expect_match(files_created, ".*testing\\.Rproj$", all = FALSE)
+  # TODO: github currently has no index, although this is likely to change
+  expect_no_match(files_created, ".*index\\.rmd$", all = FALSE)
+  expect_match(files_created, ".*\\.gitignore$", all = FALSE)
+})
+
+fs::dir_delete(new_project)
+
+# project creation - gitlab ----------------------------------------------------
+new_project <- fs::path_temp("testing")
+setup_project(new_project, type = "gitlab", add_gitignore = TRUE)
+
+test_that("project is set up", {
+  expect_true(fs::dir_exists(new_project))
+  
+  files_created <- fs::dir_ls(new_project, recurse = TRUE, all = TRUE)
+  folders_created <- fs::dir_ls(new_project, type = "directory")
+  expect_equal(sort(basename(folders_created)),
+               sort(c("R", "docs", "logs", "raw_data", "man", "results", "scripts")))
+  
+  expect_match(files_created, ".*DESCRIPTION$", all = FALSE)
+  expect_match(files_created, ".*testing\\.Rproj$", all = FALSE)
+  expect_match(files_created, ".*index\\.rmd$", all = FALSE)
+  expect_match(files_created, ".*\\.gitignore$", all = FALSE)
+  
+})
+
+fs::dir_delete(new_project)
+
+# general project creation -----------------------------------------------------
+test_that("project setup works correctly", {
+  # Error if no input provided
+  expect_error(setup_project(1))
+  
+  # Warning if incorrect name provided
+  temp_dir <- tempdir()
+  proj_with_space <- fs::file_temp("test new", tmp_dir = temp_dir)
+  expect_warning(setup_project(proj_with_space, type = "github", add_gitignore = FALSE))
+  expect_true(fs::file_exists(sub("test new", "test-new", proj_with_space)))
+  fs::dir_delete(sub("test new", "test-new", proj_with_space))
+  
+  # Warning if no project type provided
+  temp_dir <- tempdir()
+  proj_type <- fs::file_temp("test-type", tmp_dir = temp_dir)
+  expect_warning(setup_project(proj_type, add_gitignore = FALSE))
+  expect_true(fs::file_exists(proj_type))
+  fs::dir_delete(proj_type)
+})
+
+

--- a/vignettes/rprojecttemplate.Rmd
+++ b/vignettes/rprojecttemplate.Rmd
@@ -74,7 +74,7 @@ Through the console, use the `setup_project()` command. For example:
 library(rprojecttemplate)
 # Create a temporary folder using the fs package
 new_project_path <- fs::path_temp("example")
-rprojecttemplate::setup_project(new_project_path, type = "github")
+rprojecttemplate::setup_project(new_project_path, type = "github", add_gitignore = TRUE)
 ```
 
 Please note that if no `type` is provided to `setup_project()` the assumption is that the project will be hosted on GitHub, and a template created accordingly.
@@ -130,8 +130,7 @@ rprojecttemplate:::viz_project_tree(new_project_path)
 
 The main differences between this GitLab-friendly template and the GitHub-friendly template are:
 
-- `.gitlab-ci.yml` - basic template for CI that is required to add a Pages site
-- `index.rmd` - the landing page for GitLab pages needs to within the main repository (as opposed to `docs/`). Remember to knit this page everytime an edit is made, using `devtools::build_rmd("index.rmd")`.
+- `index.rmd` - the landing page for GitLab pages needs to within the main repository (as opposed to `docs/`). Remember to knit this page every time an edit is made, using `devtools::build_rmd("index.rmd")`.
 
 # Acknowledgements
 This package was heavily inspired by the [`prodigenr`](https://github.com/rostools/prodigenr) package, thus be sure to cite it if you use this `R` package.


### PR DESCRIPTION
Main changes include:

* Added tests for `setup_project()`
* Fixed bug with `setup_project()` that prevented `.gitignore` being copied over when generating project. Resulted in the addition of 2 new arguments to the function, `add_gitignore` and `gitignore_template`
* Updated vignettes/documentation